### PR TITLE
Make changes to selectors

### DIFF
--- a/src/ado/sel_vars.ado
+++ b/src/ado/sel_vars.ado
@@ -59,6 +59,9 @@ cap program drop   sel_vars
       filter_vars , varlist("`varlist'") type("MultyOptionsQuestion") yes_no_view("1")
     }
     else if ("`subcommand'" == "is_date" ) {
+      filter_vars , varlist("`varlist'") type("DateTimeQuestion")
+    }
+    else if ("`subcommand'" == "is_calendar_date" ) {
       filter_vars , varlist("`varlist'") type("DateTimeQuestion") is_timestamp("0")
     }
     else if ("`subcommand'" == "is_timestamp" ) {

--- a/src/ado/sel_vars.ado
+++ b/src/ado/sel_vars.ado
@@ -39,7 +39,6 @@ cap program drop   sel_vars
     }
     else if ("`subcommand'" == "is_text" ) {
       filter_vars , varlist("`varlist'") type("TextQuestion")
-      filter_vars , varlist("`r(varlist)'") mask negate
     }
     else if ("`subcommand'" == "follows_pattern" ) {
       filter_vars , varlist("`varlist'") type("TextQuestion") mask

--- a/src/ado/sel_vars.ado
+++ b/src/ado/sel_vars.ado
@@ -66,10 +66,7 @@ cap program drop   sel_vars
       filter_vars , varlist("`varlist'") linked_to_question_id
       local linked_to_question "`r(varlist)'"
       * combine both sets of linked questions
-      local linked : list linked_to_roster | linked_to_question
-      * pass through ds in order to have r(varlist) returned by the sub-command
-      * NOTE: r(match_count) won't be right with this kludgy solution
-      qui: ds `linked'
+      combine_varlists, union(`linked_to_roster' `linked_to_question')
     }
     else if ("`subcommand'" == "is_date" ) {
       filter_vars , varlist("`varlist'") type("DateTimeQuestion")
@@ -174,4 +171,18 @@ cap program drop   filter_vars
     if missing("`negate'") return local varlist "`mvarlist'"
     else return local varlist : list varlist - mvarlist
 
+end
+
+cap program drop   combine_varlists
+    program define combine_varlists, rclass
+
+    syntax, union(varlist) [remove(varlist)]
+
+    * Allows multiple varlists to be combined to one
+    local varlist : list uniq union
+    * Allows to remove specific variables
+    local varlist : list varlist - remove
+
+    * Return on the format r(varlist)
+    return local varlist "`varlist'"
 end

--- a/src/ado/sel_vars.ado
+++ b/src/ado/sel_vars.ado
@@ -30,7 +30,6 @@ cap program drop   sel_vars
 
     if ("`subcommand'" == "is_single_select" ) {
       filter_vars , varlist("`varlist'") type("SingleQuestion")
-      filter_vars , varlist("`r(varlist)'") linked_to_roster_id negate
     }
     else if ("`subcommand'" == "is_numeric" ) {
       filter_vars , varlist("`varlist'") type("NumericQuestion")

--- a/src/ado/sel_vars.ado
+++ b/src/ado/sel_vars.ado
@@ -56,7 +56,7 @@ cap program drop   sel_vars
       filter_vars , varlist("`varlist'") type("MultyOptionsQuestion") yes_no_view("1")
     }
     else if ("`subcommand'" == "is_multi_checkbox" ) {
-      filter_vars , varlist("`varlist'") type("MultyOptionsQuestion") yes_no_view("1")
+      filter_vars , varlist("`varlist'") type("MultyOptionsQuestion") yes_no_view("0")
     }
     else if ("`subcommand'" == "is_date" ) {
       filter_vars , varlist("`varlist'") type("DateTimeQuestion")

--- a/src/ado/sel_vars.ado
+++ b/src/ado/sel_vars.ado
@@ -58,6 +58,19 @@ cap program drop   sel_vars
     else if ("`subcommand'" == "is_multi_checkbox" ) {
       filter_vars , varlist("`varlist'") type("MultyOptionsQuestion") yes_no_view("0")
     }
+    else if ("`subcommand'" == "is_linked" ) {
+      * linked to a roster ID
+      filter_vars , varlist("`varlist'") linked_to_roster_id
+      local linked_to_roster "`r(varlist)'"
+      * linked to a (list) question
+      filter_vars , varlist("`varlist'") linked_to_question_id
+      local linked_to_question "`r(varlist)'"
+      * combine both sets of linked questions
+      local linked : list linked_to_roster | linked_to_question
+      * pass through ds in order to have r(varlist) returned by the sub-command
+      * NOTE: r(match_count) won't be right with this kludgy solution
+      qui: ds `linked'
+    }
     else if ("`subcommand'" == "is_date" ) {
       filter_vars , varlist("`varlist'") type("DateTimeQuestion")
     }
@@ -114,7 +127,7 @@ cap program drop   filter_vars
       type(string) is_integer(string) ///
       are_answers_ordered(string) ///
       yes_no_view(string) is_timestamp(string) ///
-      linked_to_roster_id mask ///
+      linked_to_roster_id linked_to_question_id mask ///
       negate ///
     ]
 
@@ -123,7 +136,7 @@ cap program drop   filter_vars
 
     * List the chars
     local value_chars "type is_integer are_answers_ordered yes_no_view is_timestamp"
-    local exist_chars "linked_to_roster_id mask"
+    local exist_chars "linked_to_roster_id linked_to_question_id mask"
     local chars "`value_chars' `exist_chars'"
 
     * Get the list of variables that has all the relevant chars

--- a/src/mdhlp/sel_vars.md
+++ b/src/mdhlp/sel_vars.md
@@ -20,7 +20,6 @@ For data collected with Survey Solutions, data users can only select variables b
 This command aims to select variables in the data based on the characteristics of their corresponding questions/variables in Designer. This selection is powered by the Designer questionnaire metadata that is attached to the Stata data by the `sel_add_metadata` as [chars](https://www.stata.com/manuals/pchar.pdf).
 
 To make selection simple, this command provides several short-hand selectors for common variable searches. Several selectors target variables linked to particular question types (e.g., text, numeric, or multi-select). Some selectors target question sub-types (e.g., multi-select captured as yes/no, multi-select where answer order is recorded, etc.). And still other selectors target characteristics that span several question types (e.g. is linked).
-<!-- NOTE: this last example doesn't exist yet, but should -->
 
 To make compound selections, this command could be used in a selection pipeline. For example, a user could first select linked questions and then select those among them that are also-multi-select.
 
@@ -61,6 +60,9 @@ __is_multi_yn__. Multi-select question where items are selected as yes/no questi
 
 __is_multi_checkbox__. Multi-select question where answers are provided as ticked checkboxes 
 (i.e. where the `Question type` field is set to `Categorical: Multi-select` and the `Display mode` field is set to `Checkboxes`).
+
+__is_linked__. Single-select or multi-select question whose answers are linked to a roster ID or a (list) question
+(i.e. where the `Source of categories` field is set to `List of question or question from roster group` and the `Bind list question or question from roster group` field is set to a roster or question).
 
 __is_date__. Date question, whether calendar date or timestamp 
 (i.e. where the `Question type` field is set to `Date`).

--- a/src/mdhlp/sel_vars.md
+++ b/src/mdhlp/sel_vars.md
@@ -51,8 +51,6 @@ __is_list__. List question
 
 __is_single_select__. Single-select questions
 (i.e., where the `Question type` field is set to `Categorical: Single-select` in Designer). 
-<!-- TODO: reconsider this decision. Better to select a broader set that subsequent selections can winnow down -->
-Note: linked questions are excluded
 
 __is_multi_select__ Multi-select question
 (i.e. where the `Question type` field is set to `Categorical: Multi-select`).

--- a/src/mdhlp/sel_vars.md
+++ b/src/mdhlp/sel_vars.md
@@ -62,11 +62,10 @@ __is_multi_yn__. Multi-select question where items are selected as yes/no questi
 __is_multi_checkbox__. Multi-select question where answers are provided as ticked checkboxes 
 (i.e. where the `Question type` field is set to `Categorical: Multi-select` and the `Display mode` field is set to `Checkboxes`).
 
-<!-- TODO: consider 
-- reassigning this sub-command to selection of variables that are dates, regardless of whether they're calendar dates or timestamps
-- retaining this description for a sub-command `is_calendar_date`
- -->
-__is_date__. Date question where the answer is provided as a selection from a calendar 
+__is_date__. Date question, whether calendar date or timestamp 
+(i.e. where the `Question type` field is set to `Date`).
+
+__is_calendar_date__. Date question where the answer is provided as a selection from a calendar 
 (i.e. where the `Question type` field is set to `Date` and the `Current timestamp (date & time)` box is not ticked).
 
 __is_timestamp__. Date question where the answer represents a timestamp. 

--- a/src/mdhlp/sel_vars.md
+++ b/src/mdhlp/sel_vars.md
@@ -39,9 +39,7 @@ __has_decimals__. Numeric questions with any number of decimal places allowed
 the `Integer` checkbox is not ticked in Designer).
 
 __is_text__. Text question 
-(i.e. where the `Question type` field is set to `Text`)
-<!-- TODO: reconsider this decision. Better to select a broader set that subsequent selections can winnow down -->
-Note: questions with a value in the `Pattern` field are excluded.
+(i.e. where the `Question type` field is set to `Text`).
 
 __follows_pattern__. Text question with a pattern specified 
 (i.e. where the `Question type` field is set to `Text` and the `Pattern` is non-empty).

--- a/src/tests/apply-metadata.do
+++ b/src/tests/apply-metadata.do
@@ -40,13 +40,19 @@
    
     sel_vars is_numeric
     return list
+
+    sel_vars follows_pattern
+    return list
     
     sel_vars is_date
     return list
     
     sel_vars is_timestamp
     return list
-    
+
+    sel_vars is_linked
+    return list
+
     ***********************************
     * Tests for sel_char
     


### PR DESCRIPTION
In particular:

- Have `is_text` **not** exclude questions with a pattern
- Have `is_single_select` **not** exclude linked questions
- Have `is_date` select all date type questions
- Add `is_calendar_date` to select date questions that capture a calendar date.
- Add `is_linked` to select (single-select and multi-select) questions that are linked to a roster or a question

There are a few things left undone here:

1. sthlp not updated/rebuilt based on md
2. `is_linked` selector made to work, but perhaps not be ideal/elegant. Might want to refactor.
3. ~~Rebase branch to reflect changes on `dev` (source for this PR's branch)~~