### PR TITLE
Issue errors if char does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `selector`
 
-Load SuSo meta data into chars and utilities using them
+Select variables by characteristic (char) or regular expression (regex)
 <!-- 
 TODO: uncomment when logo is posted
 <img src='src/dev/assets/logo.png' align="right" height="139" />

--- a/src/ado/sel_remove_metadata.ado
+++ b/src/ado/sel_remove_metadata.ado
@@ -33,6 +33,14 @@ qui {
       local relevant_vars : list relevant_vars | varlist
     }
 
+    * Error if no variables with user-specified chars found
+    if missing("`relevant_vars'") {
+      noi di as text `"{pstd}{red: Error}: No variables found with chars `chars'. {p_end}"'
+      noi di as text "{pstd}Use the {inp:misscharsok} option to suppress this error.{p_end}"
+      error 99
+      exit
+    }
+
     * Loop over relevant vars and delete the chars
     foreach var of local relevant_vars {
       foreach char of local chars {

--- a/src/ado/sel_vars.ado
+++ b/src/ado/sel_vars.ado
@@ -18,6 +18,19 @@ qui {
     local subcommand = "`anything'"
 
     *****************************************
+    * check whether SuSo selectors attached to data set
+    * by looking for data-level char
+    local list_selector_chars : char _dta[selector_chars]
+
+    * react to contents of list of variables with a SuSo type
+    if missing("`list_selector_chars'") {
+      noi di as text "{pstd}{red: Error}: No Survey Solutions metadata found. {p_end}"
+      noi di as text `"{pstd}Add metadata to your data with {browse "https://lsms-worldbank.github.io/selector/reference/sel_add_metadata.html":sel_add_metadata}. {p_end}"'
+      error 99
+      exit
+    }
+
+    *****************************************
     * initiate locals
 
     * If no varlist is provided, use all vars in current dataset

--- a/src/tests/sel_remove_metadata.do
+++ b/src/tests/sel_remove_metadata.do
@@ -101,3 +101,21 @@
 
   * check that misscharok suppresses error if try to remove non-existing chars
   sel_remove_metadata, misscharsok
+
+  * ============================================================================
+  * Test that error arises if user specifies non-existant char
+  * ============================================================================
+
+  * ----------------------------------------------------------------------------
+  * Setup
+  * ----------------------------------------------------------------------------
+
+  * Set up the test data to test on
+  use "${data_fldr}/labeled/lbl_dataset.dta", clear
+
+  * ----------------------------------------------------------------------------
+  * Test
+  * ----------------------------------------------------------------------------
+
+  capture sel_remove_metadata, chars(foo)
+  assert _rc == 99

--- a/src/tests/sel_vars.do
+++ b/src/tests/sel_vars.do
@@ -3,8 +3,8 @@
   if "`c(username)'" == "wb462869" {
       global clone "C:\Users\wb462869\github\selector"
   }
-  else if "`c(username)'" == "wb393438" {
-      global clone "C:\Users\wb393438\stata_funs\selector"
+  else if "`c(username)'" == "WB393438" {
+      global clone "C:\Users\WB393438\stata_funs\selector"
   }
 
   * Set global to ado_fldr
@@ -82,3 +82,20 @@
 
   sel_vars is_barcode
   assert "`r(varlist)'" == ""
+
+  ***********************************
+  * Tests on data without chars
+
+  * remove characteristics
+  sel_remove_metadata
+
+  * check that sel_vars fails in the absence of chars
+  capture sel_vars is_single_select
+  di as result "sel_vars fails in the absence of SuSo (qeuestion type) metadata"
+  if _rc != 0 {
+      di as result "✅ Test passed"
+  }
+  else {
+      di as error "❌ Test failed"
+      error 0
+  }


### PR DESCRIPTION
This PR closes #15 by  issuing an error char(s) do not exist. In particular:

- `sel_vars`. Check that SuSo vars exist (in data-level list of chars)
- `sel_remove_metadata`. Check that user-specified char exists

Existing code already handles the following cases:

- `sel_remove_metadata`. If neither SuSo nor user-specified chars exist, there is an error informing the user to use the `misscharok` option.
- `sel_chars`. There is no check, and I think this might make sense. The purpose of `sel_chars` is to look for variables with matching characteristics. If the characteristic doesn't exist, no variables will be selected. Perhaps we could think about some informational message to say that this char doesn't exist at all (above and beyond what the messages at the end of the command definitiona already do.